### PR TITLE
Don't show the keyboard automatically in the sdk conversation view

### DIFF
--- a/Drift/UI/Conversation View/ConversationViewController.swift
+++ b/Drift/UI/Conversation View/ConversationViewController.swift
@@ -139,11 +139,6 @@ class ConversationViewController: SLKTextViewController {
                 tableView.tableHeaderView = label
             }
             
-            DispatchQueue.main.asyncAfter(
-                deadline: DispatchTime.now() + Double(Int64(1.0 * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: {
-                    self.presentKeyboard(true)
-            })
-            
         }
     }
     


### PR DESCRIPTION
@eoinoconnell Matt mentioned this as an issue when users were quickly going in and out of the view. 