### PR TITLE
Remove p and hr tags from messages

### DIFF
--- a/Drift/Models/Message.swift
+++ b/Drift/Models/Message.swift
@@ -68,6 +68,22 @@ open class Message: Mappable, Equatable, Hashable{
         uuid                    <- map["uuid"]
         inboxId                 <- map["inboxId"]
         body                    <- map["body"]
+        
+        if body != nil {
+            if let range = body!.range(of: "<p>", options: .caseInsensitive) {
+                body!.replaceSubrange(range, with: "")
+            }
+            
+            if let range = body!.range(of: "</p>", options: .backwards) {
+                body!.replaceSubrange(range, with: "")
+            }
+            
+            if let _ = body!.range(of: "<hr", options: .caseInsensitive) {
+                body = body!.replacingOccurrences(of: "<hr [^>]+>", with: "", options: String.CompareOptions.regularExpression, range: nil)
+            }
+            
+        }
+        
         attachments             <- map["attachments"]
         contentType             <- map["contentType"]
         createdAt               <- (map["createdAt"], DriftDateTransformer())


### PR DESCRIPTION
@eoinoconnell this puts us in line with the iOS App in terms of message formatting.