### PR TITLE
Avoid Drift bleeding over into integrating apps codebase

### DIFF
--- a/Drift/Helpers/AvatarImage.swift
+++ b/Drift/Helpers/AvatarImage.swift
@@ -9,9 +9,9 @@
 import UIKit
 import AlamofireImage
 
-@IBDesignable class AvatarView: UIView {
+class AvatarView: UIView {
     
-    @IBInspectable var cornerRadius: CGFloat = 3{
+    var cornerRadius: CGFloat = 3{
         didSet{
             setUpCorners()
         }

--- a/Drift/Helpers/ColorHelper.swift
+++ b/Drift/Helpers/ColorHelper.swift
@@ -35,7 +35,7 @@ extension UIColor {
      - parameter alpha: The Alpha value to be applied to self
      - returns: self with a different alpha
      */
-    func alpha(_ alpha: CGFloat) -> UIColor{
+    func drift_alpha(_ alpha: CGFloat) -> UIColor{
         return self.withAlphaComponent(alpha)
     }
     
@@ -44,8 +44,8 @@ extension UIColor {
      
      - returns: UIColor for text when placed ontop of self
      */
-    func brightnessColor() -> UIColor{
-        if brightness() < 0.7
+    func drift_brightnessColor() -> UIColor{
+        if drift_brightness() < 0.7
         {
             return UIColor.white
         }
@@ -59,7 +59,7 @@ extension UIColor {
      
      - returns: value between 0 and 1 indicating brightness
      */
-    func brightness() -> CGFloat{
+    func drift_brightness() -> CGFloat{
         let components = self.cgColor.components
         let red = components?[0]
         let green = components?[1]

--- a/Drift/Helpers/UIDevice+ModelName.swift
+++ b/Drift/Helpers/UIDevice+ModelName.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension UIDevice {
     
-    var modelName: String {
+    var drift_modelName: String {
         var systemInfo = utsname()
         uname(&systemInfo)
         let machineMirror = Mirror(reflecting: systemInfo.machine)

--- a/Drift/Managers/PresentationManager.swift
+++ b/Drift/Managers/PresentationManager.swift
@@ -49,7 +49,7 @@ class PresentationManager: PresentationManagerDelegate {
     }
     
     func didRecieveNewMessages(_ enrichedConversations: [EnrichedConversation]) {
-        if let newMessageView = NewMessageView.fromNib() as? NewMessageView , currentShownView == nil && !conversationIsPresenting() && !enrichedConversations.isEmpty{
+        if let newMessageView = NewMessageView.drift_fromNib() as? NewMessageView , currentShownView == nil && !conversationIsPresenting() && !enrichedConversations.isEmpty{
             
             if let window = UIApplication.shared.keyWindow {
                 currentShownView = newMessageView
@@ -66,7 +66,7 @@ class PresentationManager: PresentationManagerDelegate {
     }
     
     func didRecieveNewMessage(_ message: Message) {
-        if let newMessageView = NewMessageView.fromNib() as? NewMessageView , currentShownView == nil && !conversationIsPresenting() {
+        if let newMessageView = NewMessageView.drift_fromNib() as? NewMessageView , currentShownView == nil && !conversationIsPresenting() {
             
             if let window = UIApplication.shared.keyWindow {
                 currentShownView = newMessageView
@@ -78,7 +78,7 @@ class PresentationManager: PresentationManagerDelegate {
     }
     
     func showAnnouncementCampaign(_ campaign: CampaignMessage, otherCampaigns:[CampaignMessage]) {
-        if let announcementView = AnnouncementView.fromNib() as? AnnouncementView , currentShownView == nil && !conversationIsPresenting() {
+        if let announcementView = AnnouncementView.drift_fromNib() as? AnnouncementView , currentShownView == nil && !conversationIsPresenting() {
             
             if let window = UIApplication.shared.keyWindow {
                 currentShownView = announcementView
@@ -91,7 +91,7 @@ class PresentationManager: PresentationManagerDelegate {
     }
     
     func showExpandedAnnouncement(_ campaign: CampaignMessage) {
-        if let announcementView = AnnouncementExpandedView.fromNib() as? AnnouncementExpandedView, let window = UIApplication.shared.keyWindow , !conversationIsPresenting() {
+        if let announcementView = AnnouncementExpandedView.drift_fromNib() as? AnnouncementExpandedView, let window = UIApplication.shared.keyWindow , !conversationIsPresenting() {
             currentShownView = announcementView
             announcementView.campaign = campaign
             announcementView.delegate = self

--- a/Drift/Managers/ReachabilityManager.swift
+++ b/Drift/Managers/ReachabilityManager.swift
@@ -10,9 +10,9 @@ import Foundation
 import Alamofire
 
 public extension Notification.Name {
-    static let networkStatusReachable = Notification.Name("drift-sdk-new-network-reachable")
-    static let networkStatusNotReachable = Notification.Name("drift-sdk-new-network-not-reachable")
-    static let networkStatusUnknown = Notification.Name("drift-sdk-new-network-unknown")
+    static let driftNetworkStatusReachable = Notification.Name("drift-sdk-new-network-reachable")
+    static let driftNetworkStatusNotReachable = Notification.Name("drift-sdk-new-network-not-reachable")
+    static let driftNetworkStatusUnknown = Notification.Name("drift-sdk-new-network-unknown")
 }
 
 class ReachabilityManager {
@@ -25,13 +25,13 @@ class ReachabilityManager {
             switch status {
             case .reachable(.wwan), .reachable(.ethernetOrWiFi):
                 LoggerManager.log("Network status became reachable")
-                NotificationCenter.default.post(name: .networkStatusReachable, object: self, userInfo: nil)
+                NotificationCenter.default.post(name: .driftNetworkStatusReachable, object: self, userInfo: nil)
             case .notReachable:
                 LoggerManager.log("Network status became not reachable")
-                NotificationCenter.default.post(name: .networkStatusNotReachable, object: self, userInfo: nil)
+                NotificationCenter.default.post(name: .driftNetworkStatusNotReachable, object: self, userInfo: nil)
             case .unknown:
                 LoggerManager.log("Network Status became unknown")
-                NotificationCenter.default.post(name: .networkStatusUnknown, object: self, userInfo: nil)
+                NotificationCenter.default.post(name: .driftNetworkStatusUnknown, object: self, userInfo: nil)
             }
         }
         

--- a/Drift/Managers/SocketManager.swift
+++ b/Drift/Managers/SocketManager.swift
@@ -25,7 +25,7 @@ class SocketManager {
     
     static var sharedInstance: SocketManager = {
         let socketManager = SocketManager()
-        NotificationCenter.default.addObserver(socketManager, selector: #selector(SocketManager.networkDidBecomeReachable), name: NSNotification.Name.networkStatusReachable, object: nil)
+        NotificationCenter.default.addObserver(socketManager, selector: #selector(SocketManager.networkDidBecomeReachable), name: NSNotification.Name.driftNetworkStatusReachable, object: nil)
         return socketManager
     }()
     

--- a/Drift/Models/MessageRequest.swift
+++ b/Drift/Models/MessageRequest.swift
@@ -40,7 +40,7 @@ class MessageRequest {
     
     func getContextUserAgent() -> String {
 
-        var userAgent = "Mobile App / \(UIDevice.current.modelName) / \(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
+        var userAgent = "Mobile App / \(UIDevice.current.drift_modelName) / \(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
         if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] {
             userAgent.append(" / App Version: \(version)")
         }

--- a/Drift/UI/Conversation View/ConversationViewController.swift
+++ b/Drift/UI/Conversation View/ConversationViewController.swift
@@ -24,13 +24,13 @@ class ConversationViewController: UIViewController {
         case continueConversation(conversationId: Int)
     }
     
-    lazy var emptyState = ConversationEmptyStateView.fromNib() as! ConversationEmptyStateView
+    lazy var emptyState = ConversationEmptyStateView.drift_fromNib() as! ConversationEmptyStateView
     var messages: [Message] = []
     var attachments: [Int: Attachment] = [:]
     var attachmentIds: Set<Int> = []
     var previewItem: DriftPreviewItem?
     var dateFormatter: DriftDateFormatter = DriftDateFormatter()
-    var connectionBarView: ConnectionBarView = ConnectionBarView.fromNib() as! ConnectionBarView
+    var connectionBarView: ConnectionBarView = ConnectionBarView.drift_fromNib() as! ConnectionBarView
     var connectionBarHeightConstraint: NSLayoutConstraint!
     
     var keyboardFrame: CGRect = .zero

--- a/Drift/UI/NibLoader.swift
+++ b/Drift/UI/NibLoader.swift
@@ -15,7 +15,7 @@ extension UIView {
      - parameter nibNameOrNil: - NibName or nil - If nil the Class name of self is used instead
      - returns: Instance of the class or nil
      */
-    class func fromNib<T : UIView>(_ nibNameOrNil: String? = nil) -> T? {
+    class func drift_fromNib<T : UIView>(_ nibNameOrNil: String? = nil) -> T? {
         var view: T?
         let name: String
         if let nibName = nibNameOrNil {


### PR DESCRIPTION
- Remove IBDesignable and IBInspectable from AvatarView, previously if a user had a similarly named view they would see `cornerRadius` as an option in the view inspector in storyboards
- Add drift_ identifier for extensions